### PR TITLE
DIAM-1916 Fix DeskBundle services

### DIFF
--- a/src/Diamante/DeskBundle/Resources/config/branch.xml
+++ b/src/Diamante/DeskBundle/Resources/config/branch.xml
@@ -70,11 +70,11 @@
 
         <service id="diamante.branch.api.service_oro" alias="diamante.branch.api.service" />
 
-<!--        <service id="diamante_branch.event_listener.branch_tickets_view_listener" class="%oro_datagrid.event_listener.base_orm_relation.class%">-->
-<!--            <argument type="string">branch</argument>-->
-<!--            <argument type="constant">false</argument>-->
-<!--            <tag name="kernel.event_listener" event="oro_datagrid.datagrid.build.after.diamante-branch-tickets-grid" method="onBuildAfter"/>-->
-<!--        </service>-->
+        <service id="diamante_branch.event_listener.branch_tickets_view_listener" class="%oro_datagrid.event_listener.row_selection.class%">
+            <argument type="string">branch</argument>
+            <argument type="constant">false</argument>
+            <tag name="kernel.event_listener" event="oro_datagrid.datagrid.build.after.diamante-branch-tickets-grid" method="onBuildAfter"/>
+        </service>
 
         <service id="diamante.branch.placeholder" class="%diamante.branch.placeholder.class%">
             <argument type="service" id="diamante.email_processing.mail_system_settings"/>

--- a/src/Diamante/DeskBundle/Resources/config/services.xml
+++ b/src/Diamante/DeskBundle/Resources/config/services.xml
@@ -115,11 +115,11 @@
             <tag name="diamante_desk.property.handler"/>
         </service>
 
-<!--        <service id="diamante_ticket.event_listener.ticket_attachments_view_listener" class="%oro_datagrid.event_listener.base_orm_relation.class%">-->
-<!--            <argument type="string">ticket</argument>-->
-<!--            <argument type="constant">false</argument>-->
-<!--            <tag name="kernel.event_listener" event="oro_datagrid.datagrid.build.after.diamante-ticket-attachments-grid" method="onBuildAfter"/>-->
-<!--        </service>-->
+        <service id="diamante_ticket.event_listener.ticket_attachments_view_listener" class="%oro_datagrid.event_listener.row_selection.class%">
+            <argument type="string">ticket</argument>
+            <argument type="constant">false</argument>
+            <tag name="kernel.event_listener" event="oro_datagrid.datagrid.build.after.diamante-ticket-attachments-grid" method="onBuildAfter"/>
+        </service>
 
         <service id="diamante.event_listener.oro_user_listener" class="%diamante.oro_user.OroUserSubscriber.class%">
             <argument type="service" id="service_container"/>


### PR DESCRIPTION
- Changed oro_datagrid.event_listener.base_orm_relation.class to oro_datagrid.event_listener.row_selection.class as base_orm_relation is deprecated since version since 1.4.1 in favor of RowSelectionListener and "bind_parameters" option in source
